### PR TITLE
针对Windows运行进行的修改

### DIFF
--- a/app_lam_audio2exp.py
+++ b/app_lam_audio2exp.py
@@ -34,6 +34,8 @@ try:
 except:
     pass
 
+import patoolib
+
 h5_rendering = True
 
 
@@ -119,17 +121,21 @@ def parse_configs():
 
 
 def create_zip_archive(output_zip='assets/arkitWithBSData.zip', base_dir=""):
-    import os
-    if (os.path.exists(output_zip)):
+    if os.path.exists(output_zip):
         os.remove(output_zip)
-        print(f"Reomve previous file: {output_zip}")
-    run_command = 'zip -r '+output_zip+' '+base_dir
-    os.system(run_command)
-    # check file
-    if(os.path.exists(output_zip)):
+        print(f"Remove previous file: {output_zip}")
+    
+    try:
+        # 创建压缩包
+        patoolib.create_archive(
+            archive=output_zip,
+            filenames=[base_dir],  # 要压缩的目录
+            verbosity=-1,         # 静默模式
+            program='zip'         # 指定使用zip格式
+        )
         print(f"Archive created successfully: {output_zip}")
-    else:
-        raise ValueError(f"Archive created failed: {output_zip}")
+    except Exception as e:
+        raise ValueError(f"Archive creation failed: {str(e)}")
 
 
 def demo_lam_audio2exp(infer, cfg):
@@ -260,7 +266,7 @@ def demo_lam_audio2exp(infer, cfg):
         )
 
         demo.queue()
-        demo.launch()
+        demo.launch(inbrowser=True)
 
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-spleeter==2.4.2
+#spleeter==2.4.0
 opencv_python_headless==4.11.0.86
 gradio==5.25.2
 omegaconf==2.3.0
@@ -8,3 +8,4 @@ librosa==0.11.0
 transformers==4.36.2
 termcolor==3.0.1
 numpy==1.26.3
+patool


### PR DESCRIPTION
1.spleeter==2.4.2需要的依赖，有一个没有版本。spleeter==2.4.0需要的依赖会与gradio需要的依赖产生冲突。所以先安装spleeter==2.4.0，再安装requirements。 
2.zip命令无法直接在Windows中使用，所以改为调用patoolib进行压缩。并添加依赖patool。